### PR TITLE
fixing test pyramid

### DIFF
--- a/{{cookiecutter.project_dirname}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_dirname}}/.gitlab-ci.yml
@@ -29,11 +29,11 @@ test:
     DJANGO_SETTINGS_MODULE: "{{cookiecutter.project_slug}}.settings"
     POSTGRES_PASSWORD: "postgres"
   script:
-    - python manage.py behave --simple
     - coverage run --concurrency=multiprocessing manage.py test --noinput --parallel --reverse
     - coverage combine
     - coverage html
     - coverage report
+    - python manage.py behave --simple
   coverage: '/^TOTAL.*\s+(\d+\%)$/'
   artifacts:
     paths:

--- a/{{cookiecutter.project_dirname}}/Makefile
+++ b/{{cookiecutter.project_dirname}}/Makefile
@@ -68,4 +68,4 @@ simpletest:
 	# $ make simpletest -- --keepdb --failfast --pdb --debug-sql --verbosity 2 path.to.TestClass
 	python manage.py test --configuration=Testing $(simpletestargs)
 
-test: check behave coverage
+test: check coverage behave


### PR DESCRIPTION
The reason is explained at the following link: https://martinfowler.com/articles/practical-test-pyramid.html#TheTestPyramid

Unit tests must fail before everything else.