### PR TITLE
required requirement added

### DIFF
--- a/{{cookiecutter.project_dirname}}/requirements/base.in
+++ b/{{cookiecutter.project_dirname}}/requirements/base.in
@@ -3,3 +3,4 @@
 django-configurations[cache,database,email]~=2.2.0
 django~=3.2.0
 psycopg2~=2.8.0
+django-cache-url~=3.2.3


### PR DESCRIPTION
https://github.com/20tab/django-continuous-delivery/blob/master/%7B%7Bcookiecutter.project_dirname%7D%7D/%7B%7Bcookiecutter.project_slug%7D%7D/settings.py#L159

The `CACHES` setting requires django-cache-url library