### PR TITLE
TG-449 Init XMLRunner if PYTHONBREAKPOINT is not set

### DIFF
--- a/{{cookiecutter.project_dirname}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_dirname}}/{{cookiecutter.project_slug}}/settings.py
@@ -310,9 +310,13 @@ class Testing(ProjectDefault):
     # unittest-xml-reporting (aka xmlrunner)
     # https://github.com/xmlrunner/unittest-xml-reporting#django-support
 
-    TEST_OUTPUT_FILE_NAME = "report.xml"
+    PYTHONBREAKPOINT = values.Value(environ_name="PYTHONBREAKPOINT", environ_prefix="")
 
-    TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
+    if PYTHONBREAKPOINT is None:  # pragma: no cover
+
+        TEST_OUTPUT_FILE_NAME = "report.xml"
+
+        TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
 
 
 class Remote(ProjectDefault):

--- a/{{cookiecutter.project_dirname}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_dirname}}/{{cookiecutter.project_slug}}/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/stable/ref/settings/
 """
 
+import os
 import string
 from pathlib import Path
 
@@ -310,13 +311,19 @@ class Testing(ProjectDefault):
     # unittest-xml-reporting (aka xmlrunner)
     # https://github.com/xmlrunner/unittest-xml-reporting#django-support
 
-    PYTHONBREAKPOINT = values.Value(environ_name="PYTHONBREAKPOINT", environ_prefix="")
+    @property
+    def TEST_OUTPUT_FILE_NAME(self):
+        """Return the test output file name."""
+        return "report.xml" if not os.getenv("PYTHONBREAKPOINT") else ""
 
-    if PYTHONBREAKPOINT is None:  # pragma: no cover
-
-        TEST_OUTPUT_FILE_NAME = "report.xml"
-
-        TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
+    @property
+    def TEST_RUNNER(self):
+        """Return the test runner."""
+        return (
+            "xmlrunner.extra.djangotestrunner.XMLTestRunner"
+            if not os.getenv("PYTHONBREAKPOINT")
+            else "django.test.runner.DiscoverRunner"
+        )
 
 
 class Remote(ProjectDefault):


### PR DESCRIPTION
`breakpoint()`s in tests are not working at the moment. 

The problem lies in the XML runner fiddling with the stdout in the local environment. I am proposing to do away with init'ing the XML in that very environment.

In addition, I'd like to propose removing the `ipdb` dependency altogether, as `ipython` alone covers all our practical needs. 