### PR TITLE
Support redis url secret

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/main.tf
@@ -82,5 +82,5 @@ module "deployment" {
   extra_config_values = var.extra_config_values
   extra_secret_values = var.extra_secret_values
 
-  additional_secrets = var.use_redis ? ["database-url", "cache-url"] : ["database-url"]
+  additional_secrets = var.use_redis ? ["database-url", "redis-url"] : ["database-url"]
 }

--- a/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/main.tf
@@ -65,6 +65,7 @@ module "deployment" {
 
   media_storage = var.media_storage
 
+  cache_url                       = var.cache_url
   django_admins                   = var.django_admins
   django_additional_allowed_hosts = var.django_additional_allowed_hosts
   django_default_from_email       = var.django_default_from_email

--- a/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/digitalocean-k8s/variables.tf
@@ -1,3 +1,10 @@
+variable "cache_url" {
+  type        = string
+  description = "A Django cache URL override."
+  default     = ""
+  sensitive   = true
+}
+
 variable "digitalocean_token" {
   description = "The Digital Ocean access token."
   type        = string

--- a/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/main.tf
@@ -169,6 +169,10 @@ resource "kubernetes_deployment_v1" "main" {
               }
             }
           }
+          env {
+            name  = "CACHE_URL"
+            value = "$(REDIS_URL)?key_prefix=${var.environment_slug}"
+          }
         }
       }
     }

--- a/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/main.tf
@@ -132,11 +132,11 @@ resource "kubernetes_deployment_v1" "main" {
           name  = var.service_slug
           resources {
             limits = {
-              cpu = var.service_limits_cpu
+              cpu    = var.service_limits_cpu
               memory = var.service_limits_memory
             }
             requests = {
-              cpu = var.service_requests_cpu
+              cpu    = var.service_requests_cpu
               memory = var.service_requests_memory
             }
           }
@@ -171,7 +171,7 @@ resource "kubernetes_deployment_v1" "main" {
           }
           env {
             name  = "CACHE_URL"
-            value = "$(REDIS_URL)?key_prefix=${var.environment_slug}"
+            value = coalesce(var.cache_url, "$(REDIS_URL)?key_prefix=${var.environment_slug}")
           }
         }
       }

--- a/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/modules/kubernetes/deployment/variables.tf
@@ -4,6 +4,13 @@ variable "additional_secrets" {
   default     = []
 }
 
+variable "cache_url" {
+  type        = string
+  description = "A Django cache URL override."
+  default     = ""
+  sensitive   = true
+}
+
 variable "django_additional_allowed_hosts" {
   type        = string
   description = "Additional entries of the DJANGO_ALLOWED_HOSTS environment variable ('127.0.0.1', 'localhost', the service slug and the project host are included by default)."

--- a/{{cookiecutter.project_dirname}}/terraform/other-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/other-k8s/main.tf
@@ -118,5 +118,5 @@ module "deployment" {
   extra_config_values = var.extra_config_values
   extra_secret_values = var.extra_secret_values
 
-  additional_secrets = var.use_redis ? ["database-url", "cache-url"] : ["database-url"]
+  additional_secrets = var.use_redis ? ["database-url", "redis-url"] : ["database-url"]
 }

--- a/{{cookiecutter.project_dirname}}/terraform/other-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/other-k8s/main.tf
@@ -101,6 +101,7 @@ module "deployment" {
 
   media_persistent_volume_claim_name = var.media_storage == "local" ? kubernetes_persistent_volume_claim_v1.media[0].metadata[0].name : ""
 
+  cache_url                       = var.cache_url
   django_admins                   = var.django_admins
   django_additional_allowed_hosts = var.django_additional_allowed_hosts
   django_default_from_email       = var.django_default_from_email

--- a/{{cookiecutter.project_dirname}}/terraform/other-k8s/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/other-k8s/variables.tf
@@ -1,3 +1,10 @@
+variable "cache_url" {
+  type        = string
+  description = "A Django cache URL override."
+  default     = ""
+  sensitive   = true
+}
+
 variable "django_additional_allowed_hosts" {
   type        = string
   description = "Additional entries of the DJANGO_ALLOWED_HOSTS environment variable ('127.0.0.1', 'localhost', the service slug and the project host are included by default)."


### PR DESCRIPTION
The current secret holds the `CACHE_URL` value, as expected by the `django-cache-url` package. This prevents other potential components (e.g. Celery) to access the Redis server URL, which is contained in the `CACHE_URL` value but can not easily be used as-is. Therefore I suggest storing a `REDIS_URL` value with the Redis server URL (see this [PR](https://github.com/20tab/talos/pull/237), and then populate the `CACHE_URL` environment variable from it in the Django deployment.