### PR TITLE
Make coverage fail after report

### DIFF
--- a/{{cookiecutter.project_dirname}}/pyproject.toml
+++ b/{{cookiecutter.project_dirname}}/pyproject.toml
@@ -8,7 +8,6 @@ target-version = ["py311"]
 title = "{{cookiecutter.project_name}} - Coverage"
 
 [tool.coverage.report]
-fail_under = 100
 show_missing = true
 
 [tool.coverage.run]

--- a/{{cookiecutter.project_dirname}}/pyproject.toml
+++ b/{{cookiecutter.project_dirname}}/pyproject.toml
@@ -8,6 +8,7 @@ target-version = ["py311"]
 title = "{{cookiecutter.project_name}} - Coverage"
 
 [tool.coverage.report]
+fail_under = 100
 show_missing = true
 
 [tool.coverage.run]

--- a/{{cookiecutter.project_dirname}}/scripts/report.sh
+++ b/{{cookiecutter.project_dirname}}/scripts/report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 python3 -m coverage combine
 python3 -m coverage html
-python3 -m coverage report --fail-under=100
+python3 -m coverage report

--- a/{{cookiecutter.project_dirname}}/scripts/report.sh
+++ b/{{cookiecutter.project_dirname}}/scripts/report.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 python3 -m coverage combine
 python3 -m coverage html
-python3 -m coverage report
+python3 -m coverage report --fail-under=100


### PR DESCRIPTION
Moving the failure setting from `pyproject.toml` to the `report` command specifically, allows the tests run to always print the command-line coverage report when the only failure is the coverage not being high enough.