### PR TITLE
Move default_execution_mode to tfe_project_settings resource

### DIFF
--- a/terraform/terraform-cloud/main.tf
+++ b/terraform/terraform-cloud/main.tf
@@ -60,9 +60,13 @@ data "tfe_project" "main" {
 resource "tfe_project" "main" {
   count = var.create_project ? 1 : 0
 
-  organization           = local.organization.name
-  name                   = var.project_slug
-  description            = "${var.project_name} project workspaces."
+  organization = local.organization.name
+  name         = var.project_slug
+  description  = "${var.project_name} project workspaces."
+}
+
+resource "tfe_project_settings" "main" {
+  project_id             = local.project.id
   default_execution_mode = "local"
 }
 


### PR DESCRIPTION
## Summary

Fixes `Error: Unsupported argument` on `tfe_project.default_execution_mode` raised at apply time. The argument doesn't exist on `tfe_project` in `hashicorp/tfe ~> 0.70`; the project-level default execution mode was moved to its own resource `tfe_project_settings` (introduced in v0.70.0).